### PR TITLE
Fix workflow: remove npm cache dependency

### DIFF
--- a/.github/workflows/build-explainer.yml
+++ b/.github/workflows/build-explainer.yml
@@ -55,10 +55,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
 
-      - name: "Phase 0: Install dependencies"
-        run: npm ci
+      - name: "Phase 0: Install jq"
+        run: sudo apt-get install -y jq
 
       - name: "Phase 0: Update gist — setup complete"
         run: ./scripts/update-gist-status.sh "$GIST_ID" 0 9 "Setup" "running"


### PR DESCRIPTION
## Summary
- Removes `cache: npm` from setup-node (no root package-lock.json exists)
- Replaces `npm ci` with direct `jq` install (the only dependency the workflow actually needs)
- Fixes the Phase 0 failure seen in run #28216158000

## Test plan
- [ ] Trigger a test build via the website
- [ ] Verify Phase 0 passes (checkout + node setup + jq install)