### PR TITLE
Strip GitHub Issue layer, add custom domain, harden against silent failures

### DIFF
--- a/.github/workflows/build-explainer.yml
+++ b/.github/workflows/build-explainer.yml
@@ -23,10 +23,6 @@ on:
         description: Email to notify when done
         required: false
         type: string
-      issue_number:
-        description: Tracking issue number
-        required: false
-        type: string
 
 env:
   BUILD_ID: ${{ inputs.build_id }}
@@ -34,7 +30,7 @@ env:
   TARGET_OWNER: ${{ inputs.target_owner }}
   TARGET_REPO: ${{ inputs.target_repo }}
   EXPLAINER_REPO: stuinfla/${{ inputs.target_repo }}-explainer
-  EXPLAINER_DOMAIN: ${{ inputs.target_repo }}-explainer.vercel.app
+  EXPLAINER_DOMAIN: ${{ inputs.target_repo }}.repoexplainer.isovision.ai
   GH_PAT: ${{ secrets.GH_PAT }}
   STARTED_AT: ""
 
@@ -215,8 +211,7 @@ jobs:
           RESULT=$(jq -n \
             --arg explainerUrl "https://$EXPLAINER_DOMAIN" \
             --arg repoUrl "https://github.com/$EXPLAINER_REPO" \
-            --arg issueUrl "https://github.com/${{ github.repository }}/issues/${{ inputs.issue_number }}" \
-            '{explainerUrl: $explainerUrl, repoUrl: $repoUrl, issueUrl: $issueUrl}')
+            '{explainerUrl: $explainerUrl, repoUrl: $repoUrl}')
 
           PAYLOAD=$(jq -n \
             --arg buildId "$BUILD_ID" \
@@ -240,26 +235,6 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -d "$GIST_BODY" \
             "https://api.github.com/gists/$GIST_ID"
-
-      - name: "Phase 9: Comment on tracking issue"
-        if: inputs.issue_number != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          gh issue comment "${{ inputs.issue_number }}" \
-            --repo "${{ github.repository }}" \
-            --body "$(cat <<EOF
-          ## Explainer Ready
-
-          | Item | Link |
-          |------|------|
-          | Live site | [https://$EXPLAINER_DOMAIN](https://$EXPLAINER_DOMAIN) |
-          | Repository | [github.com/$EXPLAINER_REPO](https://github.com/$EXPLAINER_REPO) |
-          | Build ID | \`$BUILD_ID\` |
-
-          Generated from [${{ inputs.target_owner }}/${{ inputs.target_repo }}](https://github.com/${{ inputs.target_owner }}/${{ inputs.target_repo }}).
-          EOF
-          )"
 
       - name: "Phase 9: Send email notification"
         if: inputs.submitter_email != '' && env.HAS_RESEND == 'true'
@@ -293,20 +268,3 @@ jobs:
             "$GIST_ID" 0 9 "$FAILED_STEP" "failed" \
             "Build failed at step: $FAILED_STEP. See workflow run for details."
 
-      - name: "On failure: comment on tracking issue"
-        if: failure() && inputs.issue_number != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          gh issue comment "${{ inputs.issue_number }}" \
-            --repo "${{ github.repository }}" \
-            --body "$(cat <<EOF
-          ## Explainer Build Failed
-
-          | Item | Detail |
-          |------|--------|
-          | Build ID | \`$BUILD_ID\` |
-          | Target | ${{ inputs.target_owner }}/${{ inputs.target_repo }} |
-          | Workflow run | [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
-          EOF
-          )"

--- a/assets/img/what-you-get-automated.svg
+++ b/assets/img/what-you-get-automated.svg
@@ -42,7 +42,7 @@
 
   <text x="130" y="212" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="700" fill="#ffffff">Your Repo</text>
   <text x="130" y="232" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">github.com/you/repo</text>
-  <text x="130" y="248" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">Opens an issue</text>
+  <text x="130" y="248" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">Submit URL to build</text>
 
   <!-- ===== ARROW ===== -->
   <line x1="230" y1="200" x2="355" y2="200" stroke="url(#arrowGrad)" stroke-width="2" stroke-dasharray="6 3"/>
@@ -78,42 +78,30 @@
   <polyline points="416,184 420,188 428,179" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   <text x="440" y="179" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">Live site</text>
   <text x="440" y="196" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#a78bfa" font-style="italic">{repo}</text>
-  <text x="472" y="196" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">-explainer.vercel.app</text>
+  <text x="472" y="196" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">.repoexplainer.isovision.ai</text>
   <rect x="800" y="170" width="98" height="22" rx="4" fill="#10b981" opacity="0.15"/>
   <text x="849" y="185" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="#10b981">Auto-deploys</text>
 
-  <!-- Item 3: Tracking Issue -->
+  <!-- Item 3: Email Notification -->
   <rect x="400" y="216" width="510" height="48" rx="8" fill="#222244" stroke="#2d2d50" stroke-width="1"/>
   <circle cx="422" cy="240" r="10" fill="#10b981" opacity="0.15"/>
   <polyline points="416,240 420,244 428,235" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="440" y="235" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">Tracking issue</text>
-  <text x="440" y="252" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">Commented with results table</text>
-  <!-- Table icon -->
-  <rect x="818" y="228" width="16" height="12" rx="2" fill="none" stroke="#f59e0b" stroke-width="1.2"/>
-  <line x1="818" y1="234" x2="834" y2="234" stroke="#f59e0b" stroke-width="1"/>
-  <line x1="826" y1="228" x2="826" y2="240" stroke="#f59e0b" stroke-width="1"/>
-  <text x="848" y="239" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="#f59e0b">Results</text>
+  <text x="440" y="235" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">Email notification</text>
+  <text x="440" y="252" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">"Your explainer is ready!"</text>
+  <!-- Mail icon -->
+  <rect x="818" y="228" width="16" height="12" rx="2" fill="none" stroke="#a78bfa" stroke-width="1.2"/>
+  <polyline points="818,230 826,236 834,230" fill="none" stroke="#a78bfa" stroke-width="1"/>
 
-  <!-- Item 4: Email Notification -->
+  <!-- Item 4: PR on README -->
   <rect x="400" y="272" width="510" height="48" rx="8" fill="#222244" stroke="#2d2d50" stroke-width="1"/>
   <circle cx="422" cy="296" r="10" fill="#10b981" opacity="0.15"/>
   <polyline points="416,296 420,300 428,291" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="440" y="291" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">Email notification</text>
-  <text x="440" y="308" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">"Your explainer is ready!"</text>
-  <!-- Mail icon -->
-  <rect x="818" y="286" width="16" height="12" rx="2" fill="none" stroke="#a78bfa" stroke-width="1.2"/>
-  <polyline points="818,288 826,294 834,288" fill="none" stroke="#a78bfa" stroke-width="1"/>
-
-  <!-- Item 5: PR on README -->
-  <rect x="400" y="328" width="510" height="48" rx="8" fill="#222244" stroke="#2d2d50" stroke-width="1"/>
-  <circle cx="422" cy="352" r="10" fill="#10b981" opacity="0.15"/>
-  <polyline points="416,352 420,356 428,347" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="440" y="347" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">PR on your README</text>
-  <text x="440" y="364" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">Badge linking to explainer site</text>
+  <text x="440" y="291" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">PR on your README</text>
+  <text x="440" y="308" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9ca3af">Badge linking to explainer site</text>
   <!-- PR merge icon -->
-  <circle cx="822" cy="347" r="3" fill="none" stroke="#10b981" stroke-width="1.5"/>
-  <line x1="822" y1="350" x2="822" y2="360" stroke="#10b981" stroke-width="1.5"/>
-  <circle cx="832" cy="347" r="3" fill="none" stroke="#a78bfa" stroke-width="1.5"/>
-  <path d="M832 350 C832 356 822 354 822 360" fill="none" stroke="#a78bfa" stroke-width="1.5"/>
-  <text x="848" y="355" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="#10b981">PR</text>
+  <circle cx="822" cy="291" r="3" fill="none" stroke="#10b981" stroke-width="1.5"/>
+  <line x1="822" y1="294" x2="822" y2="304" stroke="#10b981" stroke-width="1.5"/>
+  <circle cx="832" cy="291" r="3" fill="none" stroke="#a78bfa" stroke-width="1.5"/>
+  <path d="M832 294 C832 300 822 298 822 304" fill="none" stroke="#a78bfa" stroke-width="1.5"/>
+  <text x="848" y="299" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600" fill="#10b981">PR</text>
 </svg>

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*

--- a/www/api/build.js
+++ b/www/api/build.js
@@ -1,6 +1,6 @@
 /* =============================================================================
-   POST /api/build — Validate a GitHub repo, create a tracking issue,
-   provision a status gist, and trigger the build pipeline.
+   POST /api/build — Validate a GitHub repo, provision a status gist,
+   and trigger the build pipeline via workflow_dispatch.
    Vercel Serverless Function (Node.js runtime).
    ========================================================================== */
 
@@ -129,11 +129,6 @@ module.exports = async function handler(req, res) {
     );
   }
 
-  const description = repoData.description || "No description provided.";
-  const stars = repoData.stargazers_count || 0;
-  const language = repoData.language || "Not specified";
-  const repoUrl = repoData.html_url;
-
   // Generate build ID
   const buildId = crypto.randomUUID();
 
@@ -180,59 +175,6 @@ module.exports = async function handler(req, res) {
     );
   }
 
-  // Create tracking issue
-  const issueTitle = "Explainer request: " + fullName;
-  const issueBody = [
-    "## Explainer Request",
-    "",
-    "| Field | Value |",
-    "| --- | --- |",
-    "| **Repository** | [" + fullName + "](" + repoUrl + ") |",
-    "| **Description** | " + description.replace(/\|/g, "\\|") + " |",
-    "| **Language** | " + language + " |",
-    "| **Stars** | " + stars + " |",
-    "| **Build ID** | `" + buildId + "` |",
-    "| **Status Gist** | [View](https://gist.github.com/" + gistId + ") |",
-    "",
-    "### Next steps",
-    "",
-    "1. Run the Repo-Primer Pipeline against this repo.",
-    "2. Build the explainer site and smart zip.",
-    "3. Run all 5 quality gates (target: 95+).",
-    "4. Deploy to Vercel and create the GitHub repo.",
-    "5. Invite the repo author as a collaborator on the explainer repo.",
-    "",
-    "---",
-    "*Submitted via [Repo Explainer](https://repo-explainer-six.vercel.app).*",
-  ].join("\n");
-
-  let issueUrl = null;
-  let issueNumber = null;
-  try {
-    const issueRes = await fetch(
-      "https://api.github.com/repos/stuinfla/Repo-Explainer/issues",
-      {
-        method: "POST",
-        headers: ghHeaders(token),
-        body: JSON.stringify({
-          title: issueTitle,
-          body: issueBody,
-          labels: ["explainer-request"],
-        }),
-      }
-    );
-    if (issueRes.ok) {
-      const issueData = await issueRes.json();
-      issueUrl = issueData.html_url;
-      issueNumber = issueData.number;
-    } else {
-      const errBody = await issueRes.text();
-      console.error("GitHub issue creation failed:", issueRes.status, errBody);
-    }
-  } catch (err) {
-    console.error("Issue creation error:", err);
-  }
-
   // Trigger the build pipeline via workflow_dispatch
   const workflowInputs = {
     target_owner: owner,
@@ -240,9 +182,6 @@ module.exports = async function handler(req, res) {
     build_id: buildId,
     gist_id: gistId,
   };
-  if (issueNumber !== null) {
-    workflowInputs.issue_number = String(issueNumber);
-  }
   if (email && typeof email === "string" && email.includes("@")) {
     workflowInputs.submitter_email = email;
   }
@@ -259,9 +198,17 @@ module.exports = async function handler(req, res) {
     if (!workflowRes.ok && workflowRes.status !== 204) {
       const errBody = await workflowRes.text();
       console.error("Workflow dispatch failed:", workflowRes.status, errBody);
+      res.writeHead(502, corsHeaders());
+      return res.end(
+        JSON.stringify({ error: "Failed to start the build pipeline. Please try again." })
+      );
     }
   } catch (err) {
     console.error("Workflow dispatch error:", err);
+    res.writeHead(502, corsHeaders());
+    return res.end(
+      JSON.stringify({ error: "Failed to start the build pipeline. Please try again." })
+    );
   }
 
   const response = {
@@ -271,9 +218,6 @@ module.exports = async function handler(req, res) {
     gistId: gistId,
     repoName: fullName,
   };
-  if (issueUrl) {
-    response.issueUrl = issueUrl;
-  }
 
   res.writeHead(200, corsHeaders());
   return res.end(JSON.stringify(response));

--- a/www/api/status.js
+++ b/www/api/status.js
@@ -88,6 +88,10 @@ module.exports = async function handler(req, res) {
     );
   }
 
+  if (gistData.updated_at) {
+    status.updatedAt = gistData.updated_at;
+  }
+
   res.writeHead(200, corsHeaders());
   return res.end(JSON.stringify(status));
 };

--- a/www/main.js
+++ b/www/main.js
@@ -155,18 +155,6 @@
       wrap.appendChild(p2);
     }
 
-    if (data.issueUrl) {
-      var p3 = document.createElement("p");
-      var a3 = document.createElement("a");
-      a3.href = data.issueUrl;
-      a3.target = "_blank";
-      a3.rel = "noopener";
-      a3.className = "output-link";
-      a3.textContent = "Build details →";
-      p3.appendChild(a3);
-      wrap.appendChild(p3);
-    }
-
     outputDesc.appendChild(wrap);
   }
 
@@ -278,31 +266,8 @@
           var gistId    = data.gistId    || "";
           var repoName  = data.repoName  || fullName;
 
-          // If no buildId, the pipeline dispatch isn't live yet — show confirmation
           if (!buildId) {
-            outputTitle.textContent = "Explainer requested for " + repoName;
-            outputDesc.textContent = "";
-            var msgP = document.createElement("p");
-            msgP.textContent = data.message || "Your request has been received and will be processed.";
-            outputDesc.appendChild(msgP);
-            if (data.issueUrl) {
-              var linkP = document.createElement("p");
-              var a = document.createElement("a");
-              a.href = data.issueUrl;
-              a.target = "_blank";
-              a.rel = "noopener";
-              a.className = "output-link output-link-primary";
-              a.textContent = "Track your request on GitHub →";
-              linkP.appendChild(a);
-              outputDesc.appendChild(linkP);
-            }
-            var infoP = document.createElement("p");
-            infoP.style.cssText = "margin-top:12px;font-size:0.85rem;opacity:0.7;";
-            infoP.textContent = "The pipeline will clone your repo, build a knowledge base, author a visual explainer, generate images, run 5 quality gates, and deploy it. Estimated time: 5–10 minutes. You’ll be notified when it’s ready.";
-            outputDesc.appendChild(infoP);
-            submitBtn.disabled = false;
-            urlInput.disabled = false;
-            if (emailInput) emailInput.disabled = false;
+            showFailureResult("Server did not return a build ID. Please try again.");
             return;
           }
 
@@ -316,6 +281,11 @@
           var consecutiveErrors = 0;
           var currentDelay = 5000;
           var stopped = false;
+          var MAX_WAIT_MS = 15 * 60 * 1000;
+          var MAX_CONSECUTIVE_ERRORS = 10;
+          var STALE_THRESHOLD_MS = 3 * 60 * 1000;
+          var lastProgressStep = -1;
+          var lastProgressTime = Date.now();
 
           // Elapsed clock — update every second with estimated remaining
           elapsedInterval = setInterval(function () {
@@ -337,6 +307,12 @@
           function poll() {
             if (stopped) return;
 
+            if (Date.now() - startTime > MAX_WAIT_MS) {
+              stopTracking();
+              showFailureResult("Build timed out after 15 minutes. The pipeline may still be running — check back shortly or try again.");
+              return;
+            }
+
             var statusUrl = "/api/status?id=" +
               encodeURIComponent(buildId) +
               "&gist=" + encodeURIComponent(gistId);
@@ -348,8 +324,16 @@
                 consecutiveErrors = 0;
                 currentDelay = 5000;
 
-                // Update step statuses
                 var currentStep = typeof statusData.step === "number" ? statusData.step : -1;
+
+                if (currentStep > lastProgressStep) {
+                  lastProgressStep = currentStep;
+                  lastProgressTime = Date.now();
+                } else if (Date.now() - lastProgressTime > STALE_THRESHOLD_MS) {
+                  stopTracking();
+                  showFailureResult("Build appears stuck — no progress for 3 minutes. The pipeline may have encountered an issue. Please try again.");
+                  return;
+                }
                 for (var i = 0; i < ui.stepEls.length; i++) {
                   if (i < currentStep) {
                     setStepStatus(ui.stepEls[i], "done");
@@ -376,8 +360,7 @@
                   var result = statusData.result || {};
                   showSuccessResult({
                     siteUrl:  result.explainerUrl || "",
-                    repoUrl:  result.repoUrl      || "",
-                    issueUrl: result.issueUrl      || data.issueUrl || ""
+                    repoUrl:  result.repoUrl      || ""
                   });
                   return;
                 }
@@ -395,12 +378,15 @@
                 pollTimer = setTimeout(poll, currentDelay);
               })
               .catch(function () {
-                // Network error
                 consecutiveErrors++;
-                if (consecutiveErrors >= 3) {
-                  outputDesc.textContent = "Lost connection — retrying…";
+                if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+                  stopTracking();
+                  showFailureResult("Lost connection to the build server after multiple attempts. Please check your internet connection and try again.");
+                  return;
                 }
-                // Exponential backoff: 5s -> 10s -> 20s (capped)
+                if (consecutiveErrors >= 3) {
+                  outputDesc.textContent = "Lost connection — retrying… (" + consecutiveErrors + "/" + MAX_CONSECUTIVE_ERRORS + ")";
+                }
                 currentDelay = Math.min(currentDelay * 2, 20000);
                 pollTimer = setTimeout(poll, currentDelay);
               });


### PR DESCRIPTION
## Summary
- Remove GitHub Issue creation from build API and workflow — Gist is the sole progress bus
- Update domain pattern to `{repo}.repoexplainer.isovision.ai`
- Harden client against silent failures: 15-min hard timeout, 3-min staleness detector, 10-error connection limit
- Make workflow dispatch failure a hard error (502) instead of silently returning success
- Update SVG diagram to remove tracking issue row

## Test plan
- [ ] Verify build API returns error JSON on workflow dispatch failure
- [ ] Verify client shows failure after 15 min timeout
- [ ] Verify client detects stale builds (no progress for 3 min)
- [ ] Verify client stops polling after 10 consecutive network errors
- [ ] Trigger a test build and confirm Gist-only progress tracking works