### PR TITLE
fix: derive --on-accent from the real button fill (invisible CTA on dark accents)

### DIFF
--- a/tests/theme-contrast.test.mjs
+++ b/tests/theme-contrast.test.mjs
@@ -1,0 +1,64 @@
+// theme-contrast.test.mjs — the CTA label must be readable on ANY brain-chosen accent.
+//
+// Regression: `.cta` paints its label with `--on-accent` over `--spectrum` (falling back to
+// `--accent`). The design-system skeleton hard-codes `--on-accent: #0a0a12` (near-black), but the
+// per-repo theme overrides the fill freely. A dark accent therefore produced near-black text on a
+// near-black button — an invisible CTA. buildTheme() now derives the ink by measuring WCAG
+// contrast against the real fill, and refuses a sub-AA explicit choice.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTheme, contrast, parseColors } from '../tools/assemble-page.mjs';
+
+const AA = 4.5;
+const DARK_INK = '#0a0a12';
+const LIGHT_INK = '#f7f8fc';
+
+// buildTheme narrates its derivation on stderr; keep the test output clean.
+function quiet(fn) {
+  const orig = process.stderr.write;
+  process.stderr.write = () => true;
+  try { return fn(); } finally { process.stderr.write = orig; }
+}
+const onAccent = (palette) => {
+  const { css } = quiet(() => buildTheme({ palette }));
+  const m = css.match(/--on-accent:\s*([^;]+);/);
+  return m ? m[1].trim() : null;
+};
+// worst-case contrast of `ink` across every colour stop in `fill`
+const worst = (fill, ink) => Math.min(...parseColors(fill).map((f) => contrast(f, parseColors(ink)[0])));
+
+test('dark accent with no on-accent set → light ink is derived, and it clears AA', () => {
+  const fill = '#0b1020';
+  assert.equal(onAccent({ accent: fill }), LIGHT_INK);
+  assert.ok(worst(fill, LIGHT_INK) >= AA, `derived ink must clear AA, got ${worst(fill, LIGHT_INK)}`);
+});
+
+test('light accent with no on-accent set → dark ink is derived, and it clears AA', () => {
+  const fill = '#ffd166';
+  assert.equal(onAccent({ accent: fill }), DARK_INK);
+  assert.ok(worst(fill, DARK_INK) >= AA);
+});
+
+test('a --spectrum gradient wins over --accent, and every stop is considered', () => {
+  // accent is light, but the actual button fill (spectrum) is dark at both stops.
+  const spectrum = 'linear-gradient(90deg,#0b1020,#111827)';
+  assert.equal(onAccent({ accent: '#ffd166', spectrum }), LIGHT_INK);
+  assert.ok(worst(spectrum, LIGHT_INK) >= AA);
+});
+
+test('REGRESSION: an explicit sub-AA on-accent is overridden, not shipped', () => {
+  // This is the exact bug: dark accent + the skeleton's near-black ink = invisible label.
+  const fill = '#0b1020';
+  assert.ok(worst(fill, DARK_INK) < AA, 'fixture must actually be a failing combination');
+  assert.equal(onAccent({ accent: fill, 'on-accent': DARK_INK }), LIGHT_INK);
+});
+
+test('an explicit on-accent that already clears AA is respected', () => {
+  assert.equal(onAccent({ accent: '#0b1020', 'on-accent': '#ffffff' }), '#ffffff');
+});
+
+test('a non-colour fill (var() only) leaves --on-accent to the skeleton default', () => {
+  // Nothing parseable to measure against → do not invent a token.
+  assert.equal(onAccent({ accent: 'var(--brand)' }), null);
+});

--- a/tools/assemble-page.mjs
+++ b/tools/assemble-page.mjs
@@ -115,6 +115,54 @@ function safeCssValue(v, knob) {
   }
   return val;
 }
+// ── CTA legibility: derive --on-accent from the ACTUAL button fill (WCAG AA) ───────────────────
+// The skeleton hard-codes `--on-accent: #0a0a12` (near-black), but the per-repo theme overrides
+// `--accent` / `--spectrum` freely. A dark accent therefore paints near-black text on a near-black
+// button: the CTA label is invisible. Nothing validated that the ink could be READ on the fill —
+// only that `--accent` existed. Never trust a fixed default against a brain-chosen colour: measure
+// the contrast and pick the legible ink.
+const ON_ACCENT_DARK = '#0a0a12';
+const ON_ACCENT_LIGHT = '#f7f8fc';
+const AA_CONTRAST = 4.5;                    // WCAG AA for normal-weight label text
+
+function parseColor(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  const hex = s.match(/^#?([0-9a-f]{3,8})$/i) || s.match(/#([0-9a-f]{3,8})\b/i);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3 || h.length === 4) h = h.slice(0, 3).split('').map((c) => c + c).join('');
+    if (h.length >= 6) return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+    return null;
+  }
+  const rgb = s.match(/rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)/i);
+  return rgb ? [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])] : null;
+}
+// A gradient carries several stops; the label must stay readable over EVERY one of them.
+function parseColors(v) {
+  if (!v) return [];
+  const s = String(v);
+  const found = [...(s.match(/#[0-9a-f]{3,8}\b/gi) || []), ...(s.match(/rgba?\([^)]*\)/gi) || [])];
+  return found.map(parseColor).filter(Boolean);
+}
+const srgb = (c) => { const x = c / 255; return x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4; };
+const luminance = (rgb) => { const [r, g, b] = rgb.map(srgb); return 0.2126 * r + 0.7152 * g + 0.0722 * b; };
+function contrast(a, b) {
+  const [l1, l2] = [luminance(a), luminance(b)];
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+// Pick the ink whose WORST-CASE contrast across all fill stops is highest.
+function bestOnAccent(fills) {
+  let best = ON_ACCENT_DARK, bestMin = -1;
+  for (const cand of [ON_ACCENT_DARK, ON_ACCENT_LIGHT]) {
+    const rgb = parseColor(cand);
+    const min = Math.min(...fills.map((f) => contrast(f, rgb)));
+    if (min > bestMin) { bestMin = min; best = cand; }
+  }
+  return { color: best, minRatio: bestMin };
+}
+
 function buildTheme(concept) {
   const palette = reqObj(concept.palette, 'concept.palette');
   const decls = [];
@@ -128,6 +176,26 @@ function buildTheme(concept) {
     tokensUsed.push(`--${k}`);
   }
   if (!tokensUsed.includes('--accent')) throw new Error("concept.palette must define 'accent' (the cohesion anchor)");
+
+  // `.cta` paints its label with --on-accent over --spectrum (falling back to --accent). Derive the
+  // ink from whichever of those the theme actually set; refuse to ship a sub-AA explicit choice.
+  const get = (t) => (decls.find(([k]) => k === t) || [])[1];
+  let fillSrc = get('--spectrum');
+  let fills = parseColors(fillSrc);
+  if (!fills.length) { fillSrc = get('--accent'); fills = parseColors(fillSrc); }
+  if (fills.length) {
+    const { color: want, minRatio } = bestOnAccent(fills);
+    const explicit = get('--on-accent');
+    const explicitRgb = parseColor(explicit);
+    const explicitMin = explicitRgb ? Math.min(...fills.map((f) => contrast(f, explicitRgb))) : null;
+    if (!explicit) {
+      decls.push(['--on-accent', want]); tokensUsed.push('--on-accent');
+      process.stderr.write(`assemble-page: derived --on-accent ${want} for fill ${fillSrc} (${minRatio.toFixed(2)}:1)\n`);
+    } else if (explicitMin !== null && explicitMin < AA_CONTRAST) {
+      for (const d of decls) if (d[0] === '--on-accent') d[1] = want;
+      process.stderr.write(`assemble-page: concept.palette['on-accent']=${explicit} is only ${explicitMin.toFixed(2)}:1 on ${fillSrc} (below AA ${AA_CONTRAST}) — overriding with ${want} (${minRatio.toFixed(2)}:1)\n`);
+    }
+  }
 
   const tp = concept.typePersonality;
   let fontHref = null;
@@ -628,4 +696,14 @@ ${footer}
   });
 }
 
-try { main(); } catch (e) { fail(e.message || e); }
+// Import-safe entrypoint: run main() ONLY when invoked as a script, so the pure theme helpers can
+// be unit-tested. run-tool.mjs spawns `node <abs tool path> <build-dir>` (CONTRACT §b), so argv[1]
+// is this file and the CLI behaviour is unchanged. realpath-compared to survive symlinked paths;
+// if we cannot tell, we run — never silently skip the tool (INV-04).
+const isEntrypoint = (() => {
+  try { return Boolean(process.argv[1]) && fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url)); }
+  catch { return true; }
+})();
+if (isEntrypoint) { try { main(); } catch (e) { fail(e.message || e); } }
+
+export { buildTheme, bestOnAccent, contrast, parseColors };


### PR DESCRIPTION
## The bug

`.cta` paints its label with `--on-accent` over `--spectrum`, falling back to `--accent`:

```css
.cta { color: var(--on-accent); background: var(--spectrum); }
```

`design-system.css` hard-codes `--on-accent: #0a0a12` (near-black). But `buildTheme()` lets each repo's `concept.palette` override `--accent` / `--spectrum` with any colour, and only validates that `--accent` *exists*:

```js
if (!tokensUsed.includes('--accent')) throw new Error("concept.palette must define 'accent' ...");
```

Nothing ever checks that the ink can be **read** on the fill. So whenever the brain conceives a dark accent (very common), the page ships a near-black label on a near-black button and the call to action is invisible.

This is not intermittent. It is deterministic: dark accent means invisible CTA. Hit on a real build.

## The fix

`buildTheme()` now measures WCAG contrast against the fill the button actually uses, and picks the ink whose **worst-case** contrast across every gradient stop is highest.

* Palette omits `on-accent` -> derive it.
* Palette sets an `on-accent` below AA 4.5:1 -> override it, and say so loudly on stderr.
* Fill has no parseable colour (a bare `var()`) -> change nothing, leave the skeleton default.

Gradients matter here. A label has to stay legible over *both* ends of `linear-gradient(90deg,#0b1020,#111827)`, not just the first stop.

## Testability

`tools/assemble-page.mjs` had no test coverage and called `main()` on import, so its pure helpers could not be exercised. It is now import-safe: `main()` runs only when the file is the entrypoint, realpath-compared so symlinked paths still work, and it still runs if that cannot be determined, so a tool never silently no-ops (INV-04).

CLI behaviour is unchanged. `src/run-tool.mjs` spawns `node <abs tool path> <build-dir>`, so `argv[1]` is the tool itself. Verified:

```
$ node tools/assemble-page.mjs
{"ok":false,"outputs":{},"error":"usage: node tools/assemble-page.mjs <build-dir>"}   # exit 1
```

## Tests

Adds `tests/theme-contrast.test.mjs`, the first coverage for `assemble-page`, including a regression case that reproduces the exact failing combination (dark accent plus the skeleton's near-black ink).

```
ℹ tests 25
ℹ pass 25
ℹ fail 0
```

19 existing plus 6 new, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bz1mf76a4rc1Trqq5Z2kNL
